### PR TITLE
Fix libxposed_art.so on 64bit and also make sure its uninstalled

### DIFF
--- a/zipstatic/_all/META-INF/com/google/android/flash-script.sh
+++ b/zipstatic/_all/META-INF/com/google/android/flash-script.sh
@@ -71,15 +71,11 @@ install_overwrite() {
     return
   fi
   BACKUP="${1}.orig"
-  NO_ORIG="${1}.no_orig"
-  if [ ! -f $TARGET ]; then
-    touch $NO_ORIG || exit 1
-    set_perm $NO_ORIG 0 0 600
-  elif [ -f $BACKUP ]; then
+  if [ -f $BACKUP ]; then
     rm -f $TARGET
     gzip $BACKUP || exit 1
     set_perm "${BACKUP}.gz" 0 0 600
-  elif [ ! -f "${BACKUP}.gz" -a ! -f $NO_ORIG ]; then
+  elif [ ! -f "${BACKUP}.gz" ]; then
     mv $TARGET $BACKUP || exit 1
     gzip $BACKUP || exit 1
     set_perm "${BACKUP}.gz" 0 0 600
@@ -181,7 +177,7 @@ if [ $IS64BIT ]; then
   install_overwrite /system/lib64/libart-compiler.so      0    0 0644
   install_overwrite /system/lib64/libart-disassembler.so  0    0 0644
   install_overwrite /system/lib64/libsigchain.so          0    0 0644
-  install_overwrite /system/lib64/libxposed_art.so        0    0 0644
+  install_nobackup  /system/lib64/libxposed_art.so        0    0 0644
 fi
 
 if [ "$API" -ge "22" ]; then

--- a/zipstatic/_uninstaller/META-INF/com/google/android/flash-script.sh
+++ b/zipstatic/_uninstaller/META-INF/com/google/android/flash-script.sh
@@ -55,7 +55,7 @@ restore_backup() {
     rm -f $TARGET $NO_ORIG
     gunzip "${BACKUP}.gz"
     mv_perm $BACKUP $TARGET $2 $3 $4 $5
-  elif [ -f $NO_ORIG ]; then
+  else
     rm -f $TARGET $NO_ORIG
   fi
 }


### PR DESCRIPTION
Also remove the .no_orig stuff from the installer.  libxposed_art.so
was the only consumer.  Its intentionally left in the uninstaller
so that the uninstaller will clean it up on people's devices over time.